### PR TITLE
docs: add community meeting and election templates 📜

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/election.md
+++ b/.github/ISSUE_TEMPLATE/election.md
@@ -28,7 +28,6 @@ Please use this template to nominate candidates for community roles such as Comm
 
 ### ⏰ Nomination/Voting Timeline
 
-- **Nomination Period**: <!-- Example: 2025-08-29 to 2025-09-05 (minimum 7 days) -->
 - **Voting Period**: <!-- Example: 2025-09-06 to 2025-09-13 (minimum 7 days) -->
 - **Results Announcement**: <!-- Example: 2025-09-14 -->
 
@@ -55,8 +54,6 @@ Please use this template to nominate candidates for community roles such as Comm
 
 - Election process and role descriptions can be found in the relevant repository documentation
 - Please provide additional comments in this issue for any objections or special circumstances
-- During the voting period, all Maintainers and Committers have voting rights
-- Election results require a **simple majority** (over 50%) to pass
 - The voting process is open and transparent, and results will be announced to the community
 
 ## 🏆 Candidate Profile
@@ -96,33 +93,3 @@ If elected, please briefly describe the candidate's plans and goals for the comm
 - Ideas for community building and promotion
 - Expected time and effort commitment
 -->
-
-### 🎖️ Role Application
-
-<!-- Please select one: -->
-- [ ] Committer
-- [ ] Maintainer
-- [ ] Other Role: ______
-
-#### Role Descriptions
-
-- **Committer**: Has repository write access, can merge PRs, participates in daily maintenance
-- **Maintainer**: Has higher privileges, responsible for project direction, release management, community governance
-
-## 📊 Voting Results
-
-| Voter  | Vote      | Notes         |
-| ------ | --------- | ------------- |
-| @user1 | ✅ Approve | Notes go here |
-| @user2 | ✅ Approve | Notes go here |
-| @user3 | ❌ Reject  | Notes go here |
-
----
-
-**Voting Instructions:**
-
-- ✅ Approve: Support the candidate for this role
-- ❌ Reject: Do not support the candidate for this role
-- 🤔 Abstain: Do not participate in this vote
-
-_Last updated: 2025-08-29_

--- a/.github/ISSUE_TEMPLATE/election.md
+++ b/.github/ISSUE_TEMPLATE/election.md
@@ -1,0 +1,128 @@
+---
+name: Community Role Election
+about: Nominate candidates for community roles such as Committer, Maintainer, etc.
+labels: election, community
+---
+
+## 🗳️ Community Role Nomination
+
+Please use this template to nominate candidates for community roles such as Committer, Maintainer, etc.
+
+### 📋 Election Title
+
+<!-- Example: Maintainer Nomination for @username -->
+
+### 👤 Nominator Information
+
+- **GitHub Username**:
+- **Name**:
+- **Email**:
+- **Company/Organization**:
+
+### 🎯 Nominee Information
+
+- **GitHub Username**: @
+- **Name**:
+- **Email**:
+- **Company/Organization**:
+
+### ⏰ Nomination/Voting Timeline
+
+- **Nomination Period**: <!-- Example: 2025-08-29 to 2025-09-05 (minimum 7 days) -->
+- **Voting Period**: <!-- Example: 2025-09-06 to 2025-09-13 (minimum 7 days) -->
+- **Results Announcement**: <!-- Example: 2025-09-14 -->
+
+### ✅ Nominee Eligibility Requirements
+
+- [ ] GitHub account has two-factor authentication (2FA) enabled
+- [ ] Active participation in the project over the past three months (code, reviews, discussions, meetings, etc.)
+- [ ] Participated in at least one bi-weekly community meeting
+- [ ] Understands and agrees to follow the [Jeandle Code of Conduct](../../CODE_OF_CONDUCT.md)
+- [ ] Has read and understands the [Community Membership Guidelines](../../COMMUNITY_MEMBERSHIP.md)
+- [ ] Has read and understands the [Contributor Ladder](../../CONTRIBUTOR_LADDER.md)
+- [ ] Possesses the technical skills and experience required for the role
+- [ ] Able to commit the necessary time and responsibility for community duties
+
+### 📝 Nominator Checklist
+
+- [ ] Has communicated with the nominee and received their consent
+- [ ] Information provided is complete and accurate
+- [ ] Clear reasons for nomination and contribution history provided
+- [ ] Confirmed that the nominee has time and willingness to take on the responsibilities
+- [ ] Has informed the nominee about the election process and requirements
+
+### ℹ️ Additional Information
+
+- Election process and role descriptions can be found in the relevant repository documentation
+- Please provide additional comments in this issue for any objections or special circumstances
+- During the voting period, all Maintainers and Committers have voting rights
+- Election results require a **simple majority** (over 50%) to pass
+- The voting process is open and transparent, and results will be announced to the community
+
+## 🏆 Candidate Profile
+
+### 📊 Current Role and Contributions
+
+Please briefly describe the nominee's role in the community, projects they've participated in, and their main contributions.
+
+<!-- Please include the following information:
+- History of participation in the Jeandle community
+- Main projects and modules contributed to
+- Code contribution statistics (number of PRs, lines of code, etc.)
+- Participation in issue discussions and assistance provided
+- Community activity participation
+-->
+
+### 💡 Reasons for Nomination
+
+Please explain why you recommend this candidate and why you believe they are suitable for this role.
+
+<!-- Please consider the following aspects:
+- Technical skills and expertise
+- Community responsibility and engagement
+- Communication and collaboration abilities
+- Leadership and influence
+- Long-term commitment to the community
+-->
+
+### 🚀 Candidate's Future Plans
+
+If elected, please briefly describe the candidate's plans and goals for the community.
+
+<!-- May include:
+- Technical areas they plan to focus on
+- Community projects or improvements they wish to drive
+- Plans for mentoring new contributors
+- Ideas for community building and promotion
+- Expected time and effort commitment
+-->
+
+### 🎖️ Role Application
+
+<!-- Please select one: -->
+- [ ] Committer
+- [ ] Maintainer
+- [ ] Other Role: ______
+
+#### Role Descriptions
+
+- **Committer**: Has repository write access, can merge PRs, participates in daily maintenance
+- **Maintainer**: Has higher privileges, responsible for project direction, release management, community governance
+
+## 📊 Voting Results
+
+| Voter  | Vote      | Notes         |
+| ------ | --------- | ------------- |
+| @user1 | ✅ Approve | Notes go here |
+| @user2 | ✅ Approve | Notes go here |
+| @user3 | ❌ Reject  | Notes go here |
+
+---
+
+**Voting Instructions:**
+
+- ✅ Approve: Support the candidate for this role
+- ❌ Reject: Do not support the candidate for this role
+- 🤔 Abstain: Do not participate in this vote
+
+_Last updated: 2025-08-29_

--- a/.github/ISSUE_TEMPLATE/meeting.md
+++ b/.github/ISSUE_TEMPLATE/meeting.md
@@ -1,0 +1,33 @@
+---
+name: Community Meeting Announcement
+about: Announce the schedule, agenda, and participation details for Jeandle project community meetings
+title: "Community Meeting Announcement: YYYY-MM-DD"
+labels: meeting, community
+assignees: ''
+---
+
+## 🗓️ Meeting Schedule
+
+- Date: Please fill in the meeting date (e.g., 2025-09-12)
+- Time: Please fill in the meeting time (e.g., 20:00-21:00)
+- Format: Online meeting (please specify if asynchronous discussion is needed)
+- Meeting Link: To be added
+
+## 📋 Meeting Agenda
+
+1. Current unfixed issues and progress synchronization
+2. Community feedback and discussion
+3. Next phase planning and action
+
+Please leave comments below if you have additional agenda items.
+
+## 👥 How to Participate
+
+- Any community member (including contributors, Committers, Maintainers, etc.) may freely participate.
+- If unable to attend, please provide feedback in the comments section, and Maintainers will discuss it on your behalf during the meeting.
+- Host: Maintainers take turns hosting. Please note in the comments if any changes.
+
+## 📄 Additional Notes
+
+- Meeting notes and summaries will be published in the public repository after each meeting to help non-attendees understand the content.
+- All community members must adhere to the project's Code of Conduct. For details, see [Jeandle Community Membership](../../COMMUNITY_MEMBERSHIP.md) and our [Code of Conduct](../../CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/meeting.md
+++ b/.github/ISSUE_TEMPLATE/meeting.md
@@ -21,12 +21,6 @@ assignees: ''
 
 Please leave comments below if you have additional agenda items.
 
-## 👥 How to Participate
-
-- Any community member (including contributors, Committers, Maintainers, etc.) may freely participate.
-- If unable to attend, please provide feedback in the comments section, and Maintainers will discuss it on your behalf during the meeting.
-- Host: Maintainers take turns hosting. Please note in the comments if any changes.
-
 ## 📄 Additional Notes
 
 - Meeting notes and summaries will be published in the public repository after each meeting to help non-attendees understand the content.

--- a/MEETING.md
+++ b/MEETING.md
@@ -1,0 +1,28 @@
+# Jeandle Project Community Meeting Guide
+
+To promote community communication and collaboration, we hold bi-weekly community meetings organized and hosted by Maintainers. These meetings are used to synchronize progress, resolve issues, and plan for the next phase. All Jeandle contributors and anyone interested in the Jeandle project are welcome to participate.
+
+## Meeting Schedule
+
+- **Frequency**: Every two weeks, with specific times determined by Maintainers based on current community situation and announced in advance through issues.
+- **Format**: Online meetings, which may be changed to asynchronous discussions (via email, issues, etc.) when necessary.
+- **Duration**: Typically 60 minutes.
+- **Records**: Meeting notes and summaries will be published in the public repository after each meeting to help non-attendees understand the content.
+
+## Meeting Agenda (Example)
+
+1. Current matters and progress synchronization
+2. Community feedback and open discussion
+3. Next phase planning and action items
+
+## How to Participate
+
+- Any community member (including contributors, Committers, Maintainers, etc.) may freely participate.
+- If unable to attend, you can provide feedback in advance through community channels, and Maintainers will discuss it on your behalf during the meeting.
+- Hosting follows a Maintainer rotation system. If the current host cannot attend, they may temporarily delegate hosting to another Maintainer or Committer.
+
+## Additional Notes
+
+- If you have objections to role promotions, responsibility assignments, or voting results, you may raise them during the meeting.
+- Role permissions and responsibilities may be adjusted as the project evolves. Any changes require approval from the governance committee and confirmation through the voting process.
+- All community members must adhere to the project's Code of Conduct. Violators may have their corresponding permissions revoked. For details, see [Jeandle Community Membership](COMMUNITY_MEMBERSHIP.md) and our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Any significant changes to this governance repository will be discussed among th
 
 If you discover a security vulnerability in the Jeandle project, please report it privately to our security team. We take security issues seriously and will respond promptly to address any concerns.
 
-To report a security issue, we use GitHub security advisory to report vulnerabilities, for more information, see our [security advisories](https://github.com/jeandle/jeandle-jdk/blob/main/SECURITY.md) in the main project repository.
+To report a vulnerability, please open a security advisory on Github. For more information, see [jeandle-jdk security](https://github.com/jeandle/jeandle-jdk/blob/main/SECURITY.md) and [jeandle-llvm security](https://github.com/jeandle/jeandle-llvm/blob/main/SECURITY.md).
 
 ## Contact Us
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Any significant changes to this governance repository will be discussed among th
 
 If you discover a security vulnerability in the Jeandle project, please report it privately to our security team. We take security issues seriously and will respond promptly to address any concerns.
 
-To report a security issue, please contact the project maintainers directly through our community channels or email the maintainers listed in [MAINTAINERS.md](MAINTAINERS.md).
+To report a security issue, we use GitHub security advisory to report vulnerabilities, for more information, see our [security advisories](https://github.com/jeandle/jeandle-jdk/blob/main/SECURITY.md) in the main project repository.
 
 ## Contact Us
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # Jeandle Project Governance
 
-- [Core Principles](#core-principles)
-- [Roles and Responsibilities](#roles-and-responsibilities)
-- [How to Contribute](#how-to-contribute)
-- [Code of Conduct](#code-of-conduct)
-- [Amending this Repository](#amending-this-repository)
-- [Security Reporting](#security-reporting)
-- [Contact Us](#contact-us)
-
 Welcome to the Jeandle project governance guide! We believe that open and transparent collaboration is the foundation for building a healthy, inclusive, and efficient community.
 
 This repository details how the project operates, including our roles, responsibilities, and decision-making processes. We are committed to keeping our procedures simple and practical, so everyone can easily understand how to participate in the project and how it works.
@@ -31,9 +23,21 @@ We welcome contributions from everyone! If you are interested in contributing, o
 
 We follow the [Code of Conduct](CODE_OF_CONDUCT.md) to ensure a safe and respectful environment for all. We expect all community members to abide by these guidelines. If you witness any violations, please contact the project maintainers.
 
+## Community Meetings
+
+We hold bi-weekly community meetings to promote communication and collaboration within our community. These meetings are organized and hosted by Maintainers to synchronize progress, resolve issues, and plan for future development. All contributors and anyone interested in the Jeandle project are welcome to participate.
+
+For detailed information about meeting schedules, agenda, and participation guidelines, please see our [Community Meeting Guide](MEETING.md).
+
 ## Amending this Repository
 
 Any significant changes to this governance repository will be discussed among the maintainer team and require a vote to pass. For minor adjustments and clarifications, maintainers may make changes after reaching a general consensus.
+
+## Security Reporting
+
+If you discover a security vulnerability in the Jeandle project, please report it privately to our security team. We take security issues seriously and will respond promptly to address any concerns.
+
+To report a security issue, please contact the project maintainers directly through our community channels or email the maintainers listed in [MAINTAINERS.md](MAINTAINERS.md).
 
 ## Contact Us
 


### PR DESCRIPTION
- Introduce issue templates for community role elections
- Add meeting announcement template for bi-weekly syncs
- Update README with community meeting information
- Create detailed meeting guide in MEETING.md
- Enable blank issues in GitHub configuration