### PR TITLE
docs: add community meeting summary template 📜

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting_summary.md
+++ b/.github/ISSUE_TEMPLATE/meeting_summary.md
@@ -1,0 +1,63 @@
+---
+name: Community Meeting Summary
+about: Meeting summary and notes for Jeandle community meetings
+title: "Meeting Summary: YYYY-MM-DD"
+labels: meeting, summary, community
+assignees: ''
+---
+
+## 📅 Meeting Information
+
+- **Date & Time**: [Fill in date and time, e.g., September 6, 2025, 14:00 - 15:00]
+- **Location/Format**: [Fill in online meeting link or venue]
+- **Host**: [Fill in meeting host name or ID]
+- **Note Taker**: [Fill in meeting recorder name or ID]
+- **Related Links**: [Link to the meeting announcement issue]
+
+## 👥 Attendees
+
+- [Fill in attendee names/IDs, or simply note "All community members"]
+- [Or briefly describe attendance situation, e.g., number of participants]
+
+## 📋 Main Topics (Last Week Review & This Week Progress)
+
+### 🚀 Project/Feature Updates
+- **[Project A]**: [Brief description of last week's progress, whether expected goals were met, issues encountered]
+- **[Project B]**: [Brief description of this week's plan, what support is needed]
+- ...
+
+### 🎉 Community Activities/Events
+- **[Event X]**: [Review of last activity's effectiveness, data, feedback]
+- **[Event Y]**: [Announcement of current or next activity, volunteer recruitment, etc.]
+- ...
+
+### 🎊 New Member Introductions/Congratulations
+- [e.g., Welcome new contributor @username]
+- [e.g., Congratulations to @username for progress on project YYY]
+- *Note: This is an important part of motivating community members and creating a positive atmosphere, similar to recognizing contributors in open source communities.*
+
+### 💬 Open Discussion/Proposals
+- **[Topic 1]**: [Brief description of topic to be discussed, proposer]
+- **[Topic 2]**: [Brief description of topic to be discussed, proposer]
+- ...
+
+## ✅ Action Items (Next Steps & Owners)
+
+- [ ] **[Task 1]**: [Specific task description, e.g., Update documentation X] - Assigned to: @username - Due: YYYY-MM-DD
+- [ ] **[Task 2]**: [Specific task description, e.g., Initiate PR review Y] - Assigned to: @username - Due: YYYY-MM-DD
+- [ ] ...
+
+*Note: Each action item should have a clear owner and deadline for follow-up tracking.*
+
+## 📎 Attachments & References
+
+- [Meeting recording link (if available)]
+- [Relevant documents and links for easy reference and management]
+- [Additional resources discussed during the meeting]
+
+---
+
+**Next Meeting**: [Date and time of next meeting, if scheduled]
+
+
+


### PR DESCRIPTION
- Introduce meeting summary template for Jeandle community
- Include sections for meeting info, attendees, and topics
- Add structure for action items with owners and deadlines
- Provide placeholders for attachments and references
- Support documentation of community updates and discussions